### PR TITLE
Remove unneeded dependency

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -19,7 +19,6 @@ cc_binary {
         "libbase",
         "libutils",
         "libhidlbase",
-        "libhidltransport",
         "android.hardware.sensors@1.0",
         "libvisclient",
         "libuws",


### PR DESCRIPTION
libhidltransport is not needed for sensors HAL.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>